### PR TITLE
Make ExcelImportController asynchronous again

### DIFF
--- a/src/GiveCRM.Web/Controllers/ExcelImportController.cs
+++ b/src/GiveCRM.Web/Controllers/ExcelImportController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
 using GiveCRM.Web.Models;
@@ -54,7 +55,7 @@ namespace GiveCRM.Web.Controllers
             }
 
             // Process the file
-            ImportAsync(file.InputStream);
+            Task.Factory.StartNew(() => ImportAsync(file.InputStream));
             
             return RedirectToAction("Index", "Member");
         }


### PR DESCRIPTION
In the demo, the ExcelImportController was asynchronous so that the site remained responsive whilst a large Excel file was being imported.  This seems to have got lost in the move of the functionality to the main site, so I've added it back in here.
