### PR TITLE
Fix a couple of niggles from the wiki

### DIFF
--- a/src/GiveCRM.Web/Controllers/CampaignController.cs
+++ b/src/GiveCRM.Web/Controllers/CampaignController.cs
@@ -235,7 +235,7 @@ namespace GiveCRM.Web.Controllers
             var campaignClone = new Campaign
                                          {
                                              Id = 0,
-                                             Description = campaign.Description + " (" + Resources.Literal_Cloned + ")",
+                                             Description = campaign.Description,
                                              IsClosed = "N",
                                              Name = campaign.Name + " (" + Resources.Literal_Cloned + ")",
                                              RunOn = null

--- a/src/GiveCRM.Web/GiveCRM.Web.csproj
+++ b/src/GiveCRM.Web/GiveCRM.Web.csproj
@@ -295,9 +295,6 @@
     <Content Include="Views\Donation\DonationList.cshtml" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Views\Donation\DonationList.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Views\Shared\_GlobFooter.cshtml" />
     <Content Include="Views\Shared\_GlobHeader.cshtml">
       <SubType>Code</SubType>

--- a/src/GiveCRM.Web/Views/Donation/DonationList.cshtml
+++ b/src/GiveCRM.Web/Views/Donation/DonationList.cshtml
@@ -1,4 +1,5 @@
-﻿@model IEnumerable<GiveCRM.Models.Donation>
+﻿@using System.Globalization
+@model IEnumerable<GiveCRM.Models.Donation>
 
 @{
     Layout = null;
@@ -13,7 +14,7 @@
 {
     <tr>
         <td>@donation.Date.ToLongDateString()</td>
-        <td>@donation.Amount</td>
+        <td>@donation.Amount.ToString("C2", NumberFormatInfo.CurrentInfo)</td>
     </tr>
 }
 


### PR DESCRIPTION
This pull request removes the string "(Copy)" from the description field of a cloned campaign (it is still displayed in the title field), and formats donation amounts as currencies, to two decimal places.  In the latter change, I have assumed that ASP.NET sets the Current Culture based on the headers received from the browser, so hopefully the currency should display according to the user's culture settings.  This might not be desirable in the long-term!  I think this change will over-ride whatever currency the charity works in based on the user's settings.  Without any tracking of that information at the moment, though, it's not something I can address. 

It also removes a duplicate file reference from the GiveCRM.Web project file.
