### PR TITLE
Add Sql Server Compact Edition v4.0 as a NuGet package.

### DIFF
--- a/src/GiveCRM.DataAccess.Test/GiveCRM.DataAccess.Test.csproj
+++ b/src/GiveCRM.DataAccess.Test/GiveCRM.DataAccess.Test.csproj
@@ -69,7 +69,10 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91" />
+    <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\SqlServerCompact.4.0.8482.1\lib\System.Data.SqlServerCe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -139,6 +142,13 @@
   <Target Name="BeforeBuild">
     <Exec Command="&quot;$(SolutionDir)Tools\NuGet&quot; install &quot;$(ProjectDir)packages.config&quot; -o 			&quot;$(SolutionDir)packages&quot;" />
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>
+if not exist "$(TargetDir)x86" md "$(TargetDir)x86"
+xcopy /s /y "$(SolutionDir)packages\SqlServerCompact.4.0.8482.1\NativeBinaries\x86\*.*" "$(TargetDir)x86"
+if not exist "$(TargetDir)amd64" md "$(TargetDir)amd64"
+xcopy /s /y "$(SolutionDir)packages\SqlServerCompact.4.0.8482.1\NativeBinaries\amd64\*.*" "$(TargetDir)amd64"</PostBuildEvent>
+  </PropertyGroup>
   <!-- <Target Name="AfterBuild">
   </Target>
   -->

--- a/src/GiveCRM.DataAccess.Test/packages.config
+++ b/src/GiveCRM.DataAccess.Test/packages.config
@@ -4,4 +4,5 @@
   <package id="Simple.Data.Ado" version="0.9.8.2" />
   <package id="Simple.Data.Core" version="0.9.8.2" />
   <package id="Simple.Data.SqlCompact40" version="0.9.8.2" />
+  <package id="SqlServerCompact" version="4.0.8482.1" />
 </packages>


### PR DESCRIPTION
The build agent does not have SQL Server Compact edition installed, whereas developer machines often do.  When it is installed in this manner, it is placed in the GAC, making it easy to reference, but fatal to build agents.  This pull request pulls in SQL Compact as a NuGet package.  

This will take the number of failing automated tests down from twelve to three.  The remaining three @adrianbanks has said he'll look at as part of issue #60.
