### PR TITLE
Merge of changes to the Campaign Show view so that there's no way to make changes

### DIFF
--- a/src/GiveCRM.Models/Campaign.cs
+++ b/src/GiveCRM.Models/Campaign.cs
@@ -25,5 +25,10 @@ namespace GiveCRM.Models
         {
             return Id + " " + Name;
         }
+
+        public bool IsReadonly
+        {
+            get { return IsCommitted || (IsClosed == "Y"); }
+        }
     }
 }

--- a/src/GiveCRM.Web/Controllers/CampaignController.cs
+++ b/src/GiveCRM.Web/Controllers/CampaignController.cs
@@ -120,7 +120,8 @@ namespace GiveCRM.Web.Controllers
                                         }).ToList(),
                                 NoSearchFiltersText = Resources.Literal_NoSearchFiltersText,
                                 NoMatchingMembersText = Resources.Literal_NoMatchingMembersText,
-                                ApplicableMembers = applicableMembers.ToList()
+                                ApplicableMembers = applicableMembers.ToList(),
+                                IsReadonly = campaign.IsReadonly
                             };
 
             return View(model);

--- a/src/GiveCRM.Web/Models/Campaigns/CampaignShowViewModel.cs
+++ b/src/GiveCRM.Web/Models/Campaigns/CampaignShowViewModel.cs
@@ -12,6 +12,7 @@
         public string NoSearchFiltersText { get; set; }
         public string NoMatchingMembersText { get; set; }
         public IList<string> QuickLinks { get; set; }
+        public bool IsReadonly { get; set; }
 
         public CampaignShowViewModel() : this(string.Empty)
         {}

--- a/src/GiveCRM.Web/Views/Campaign/Show.cshtml
+++ b/src/GiveCRM.Web/Views/Campaign/Show.cshtml
@@ -51,17 +51,19 @@
                     foreach (MemberSearchFilterViewModel filterViewModel in Model.SearchFilters) {
                         <li>
                             @filterViewModel.CriteriaDisplayText
-                            @Html.ActionLink("[x]", "DeleteMemberSearchFilter", new {
-                                campaignId = filterViewModel.CampaignId,
-                                memberSearchFilterId = filterViewModel.MemberSearchFilterId
-                            })
+                            @if(Model.IsReadonly == false) {
+                                @Html.ActionLink("[x]", "DeleteMemberSearchFilter", new {
+                                    campaignId = filterViewModel.CampaignId,
+                                    memberSearchFilterId = filterViewModel.MemberSearchFilterId
+                                })
+                            }
                         </li>
                     }
                 }
 
-                            @if (Model.Campaign.Id > 0) {
-                <li>@Html.ActionLink("Add new search filter", "AddMembershipSearchFilter", new { campaignId = Model.Campaign.Id })</li>
-                            }
+                @if (Model.Campaign.Id > 0 && Model.IsReadonly == false) {
+                    <li>@Html.ActionLink("Add new search filter", "AddMembershipSearchFilter", new { campaignId = Model.Campaign.Id })</li>
+                }
             </ul>
 
             <h3>Matched Recipient Listing</h3>
@@ -80,26 +82,34 @@
                              </ul>
                          }
                          
-                        <div class="actions clearfix">
-                <input type="submit" value="Save Campaign" class="btn primary @formWidthClass" />
-            </div>
-                }
+                        if (Model.IsReadonly == false)
+                        {
+                            <div class="actions clearfix">
+                            <input type="submit" value="Save Campaign" class="btn primary @formWidthClass" />
+                            </div>
+                        }
+        }
         </div>
     
         <div class="sidebar span-one-third">
             <h2>Quick Links</h2>
         
             <ul class="toolbar">                            
-                            @if (Model.Campaign.Id > 0) {
+                            @if (Model.Campaign.Id > 0)
+                            {
 
-                                if (Model.Campaign.IsCommitted == true && Model.Campaign.IsClosed == "N") {
+                                if (Model.Campaign.IsCommitted == true && Model.Campaign.IsClosed == "N")
+                                {
                                     <li>@Html.ActionLink("Close campaign", "CloseCampaign", new { campaignId = Model.Campaign.Id })</li>                                
                                 }
 
-                                if (Model.Campaign.IsCommitted == false && Model.Campaign.IsClosed == "N") {
+                                if (Model.Campaign.IsCommitted == false && Model.Campaign.IsClosed == "N")
+                                {
                                     <li>@Html.ActionLink("Commit campaign", "CommitCampaign", new { campaignId = Model.Campaign.Id })</li>
-                                } else {
-                                    <li>@Html.ActionLink("Download mailing list", "DownloadMailingList", new { id = Model.Campaign.Id, name=Model.Campaign.Name })</li>
+                                }
+                                else
+                                {
+                                    <li>@Html.ActionLink("Download mailing list", "DownloadMailingList", new { id = Model.Campaign.Id, name = Model.Campaign.Name })</li>
                                 }
                                 
                                 <li>@Html.ActionLink("Copy this campaign", "Clone", new { id = Model.Campaign.Id })</li>

--- a/src/GiveCRM.Web/Web.config
+++ b/src/GiveCRM.Web/Web.config
@@ -16,7 +16,7 @@
     <add name="ApplicationServices"
          connectionString="data source=.\SQLEXPRESS;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|aspnetdb.mdf;User Instance=true"
          providerName="System.Data.SqlClient" />
-    <add name="GiveCRM" connectionString="server=.\SQLEXPRESS;database=GiveCRM;trusted_connection=true;" providerName="System.Data.SqlClient" />
+    <add name="GiveCRM" connectionString="server=(local);database=GiveCRM;trusted_connection=true;" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="1.0.0.0" />


### PR DESCRIPTION
...f the campaign is readonly.

Technically I think now this should actually be split into separate views after all, because there's still an HTML form even if the view is readonly, and trying to have "is it readonly or not" logic everywhere is going to be troublesome. However, the "bug" is technically fixed for now I suppose.

Fixes #68.
