### PR TITLE
Temporarily disable MvcBuildViews to diagnose build failiure.

### DIFF
--- a/src/GiveCRM.Web/GiveCRM.Web.csproj
+++ b/src/GiveCRM.Web/GiveCRM.Web.csproj
@@ -13,7 +13,7 @@
     <RootNamespace>GiveCRM.Web</RootNamespace>
     <AssemblyName>GiveCRM.Web</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <MvcBuildViews>true</MvcBuildViews>
+    <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This commit should "fix" the build (i.e., stop the compilation failing).  If this is the case, I'll drop @stack72 a line to ask him to sort out the build agent so we can re-enable the building of MVC Views on our agents.
