### PR TITLE
Licensing

### DIFF
--- a/licence.txt
+++ b/licence.txt
@@ -1,0 +1,7 @@
+Copyright (c) 2012 GiveCRM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/GiveCRM.ImportExport/GiveCRM.ImportExport.Test/GiveCRM.ImportExport.Test.csproj
+++ b/src/GiveCRM.ImportExport/GiveCRM.ImportExport.Test/GiveCRM.ImportExport.Test.csproj
@@ -40,7 +40,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EPPlus, Version=2.9.0.1, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL" />
+    <Reference Include="EPPlus, Version=3.0.0.2, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\EPPlus.3.0.0.2\lib\net20\EPPlus.dll</HintPath>
+    </Reference>
     <Reference Include="Ionic.Zip">
       <HintPath>..\..\packages\NPOI.1.2.3\lib\2.0\Ionic.Zip.dll</HintPath>
     </Reference>

--- a/src/GiveCRM.ImportExport/GiveCRM.ImportExport.Test/packages.config
+++ b/src/GiveCRM.ImportExport/GiveCRM.ImportExport.Test/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EPPlus" version="3.0.0.2" />
   <package id="NPOI" version="1.2.3" />
   <package id="NSubstitute" version="1.3.0.0" />
   <package id="NUnit" version="2.5.10.11092" />

--- a/src/GiveCRM.ImportExport/GiveCRM.ImportExport/GiveCRM.ImportExport.csproj
+++ b/src/GiveCRM.ImportExport/GiveCRM.ImportExport/GiveCRM.ImportExport.csproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EPPlus">
-      <HintPath>..\..\packages\EPPlus.2.9.0.1\lib\2.0\EPPlus.dll</HintPath>
+      <HintPath>..\..\packages\EPPlus.3.0.0.2\lib\net20\EPPlus.dll</HintPath>
     </Reference>
     <Reference Include="Ionic.Zip">
       <HintPath>..\..\packages\NPOI.1.2.3\lib\2.0\Ionic.Zip.dll</HintPath>

--- a/src/GiveCRM.ImportExport/GiveCRM.ImportExport/packages.config
+++ b/src/GiveCRM.ImportExport/GiveCRM.ImportExport/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EPPlus" version="2.9.0.1" />
+  <package id="EPPlus" version="3.0.0.2" />
   <package id="NPOI" version="1.2.3" />
   <package id="NUnit" version="2.5.10.11092" />
 </packages>

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
-  <repository path="..\GiveCRM.ImportExport\GiveCRM.ImportExport\packages.config" />
-  <repository path="..\GiveCRM.Web\packages.config" />
-  <repository path="..\GiveCRM.DataAccess.Test\packages.config" />
-  <repository path="..\GiveCRM.ImportExport\GiveCRM.ImportExport.Test\packages.config" />
-  <repository path="..\GiveCRM.DummyDataGenerator\packages.config" />
-  <repository path="..\GiveCRM.Web.Tests\packages.config" />
   <repository path="..\GiveCRM.BusinessLogic.Tests\packages.config" />
+  <repository path="..\GiveCRM.DataAccess.Test\packages.config" />
   <repository path="..\GiveCRM.DataAccess\packages.config" />
+  <repository path="..\GiveCRM.DummyDataGenerator\packages.config" />
+  <repository path="..\GiveCRM.ImportExport.Test\packages.config" />
+  <repository path="..\GiveCRM.ImportExport\packages.config" />
   <repository path="..\LoggingService\packages.config" />
+  <repository path="..\GiveCRM.Web.Tests\packages.config" />
+  <repository path="..\GiveCRM.Web\packages.config" />
 </repositories>


### PR DESCRIPTION
Add a licence.txt file containing the text of the MIT licence.  Upgrade EPPlus to v3 as it is LGPL-licensed (rather than GPL).

NuGet decided to rewrite the repositories.config file during the upgrade of EPPlus, so there's a bit of a horrid diff on that file.
