### PR TITLE
Database connection creation moved to abstraction for IoC purposes

### DIFF
--- a/src/GiveCRM.DataAccess.Test/CampaignsTest.cs
+++ b/src/GiveCRM.DataAccess.Test/CampaignsTest.cs
@@ -26,7 +26,7 @@ namespace GiveCRM.DataAccess.Test
         [Test]
         public void InsertCampaign()
         {
-            var campaigns = new Campaigns();
+            var campaigns = new Campaigns(new FakeDatabaseProvider(db));
             var campaign = new Campaign
                                {
                                    Name = "Test",

--- a/src/GiveCRM.DataAccess.Test/FacetSetUpHelper.cs
+++ b/src/GiveCRM.DataAccess.Test/FacetSetUpHelper.cs
@@ -7,7 +7,7 @@ namespace GiveCRM.DataAccess.Test
     {
         public static Facet CreateListFacet()
         {
-            var facets = new Facets();
+            var facets = new Facets(new DatabaseProvider());
             var facet = new Facet
                             {
                                 Type = FacetType.List,
@@ -25,7 +25,7 @@ namespace GiveCRM.DataAccess.Test
 
         public static Facet CreateFreeTextFacet()
         {
-            var facets = new Facets();
+            var facets = new Facets(new DatabaseProvider());
             var facet = new Facet
                             {
                                 Type = FacetType.FreeText,

--- a/src/GiveCRM.DataAccess.Test/FacetsTest.cs
+++ b/src/GiveCRM.DataAccess.Test/FacetsTest.cs
@@ -8,11 +8,13 @@ namespace GiveCRM.DataAccess.Test
     [TestFixture]
     public class FacetsTest
     {
-        private readonly dynamic db = Database.OpenNamedConnection("GiveCRM");
+        private IDatabaseProvider databaseProvider;
 
         [SetUp]
         public void SetUp()
         {
+            databaseProvider = new DatabaseProvider();
+            dynamic db = databaseProvider.GetDatabase();
             db.Donations.DeleteAll();
             db.CampaignRuns.DeleteAll();
             db.Campaigns.DeleteAll();
@@ -28,7 +30,7 @@ namespace GiveCRM.DataAccess.Test
         public void InsertFreeTextFacet()
         {
             var facet = FacetSetUpHelper.CreateFreeTextFacet();
-            facet = new Facets().GetById(facet.Id);
+            facet = new Facets(databaseProvider).GetById(facet.Id);
             Assert.AreNotEqual(0, facet.Id);
             Assert.AreEqual(FacetType.FreeText, facet.Type);
             Assert.AreEqual("FreeTextTest", facet.Name);
@@ -56,7 +58,7 @@ namespace GiveCRM.DataAccess.Test
         {
             var facet = FacetSetUpHelper.CreateListFacet();
 
-            facet = new Facets().GetById(facet.Id);
+            facet = new Facets(databaseProvider).GetById(facet.Id);
             Assert.AreNotEqual(0, facet.Id);
             Assert.AreEqual(FacetType.List, facet.Type);
             Assert.AreEqual("ListTest", facet.Name);
@@ -76,11 +78,11 @@ namespace GiveCRM.DataAccess.Test
             FacetSetUpHelper.CreateFreeTextFacet();
             FacetSetUpHelper.CreateListFacet();
 
-            var facet = new Facets().GetAll().FirstOrDefault(f => f.Type == FacetType.FreeText);
+            var facet = new Facets(databaseProvider).GetAll().FirstOrDefault(f => f.Type == FacetType.FreeText);
             Assert.IsNotNull(facet);
             Assert.AreEqual("FreeTextTest", facet.Name);
 
-            facet = new Facets().GetAll().FirstOrDefault(f => f.Type == FacetType.List);
+            facet = new Facets(databaseProvider).GetAll().FirstOrDefault(f => f.Type == FacetType.List);
             Assert.IsNotNull(facet);
             Assert.AreNotEqual(0, facet.Id);
             Assert.AreEqual(FacetType.List, facet.Type);

--- a/src/GiveCRM.DataAccess.Test/FakeDatabaseProvider.cs
+++ b/src/GiveCRM.DataAccess.Test/FakeDatabaseProvider.cs
@@ -1,0 +1,17 @@
+namespace GiveCRM.DataAccess.Test
+{
+    public class FakeDatabaseProvider : IDatabaseProvider
+    {
+        private readonly dynamic database;
+
+        public FakeDatabaseProvider(dynamic database)
+        {
+            this.database = database;
+        }
+
+        public dynamic GetDatabase()
+        {
+            return this.database;
+        }
+    }
+}

--- a/src/GiveCRM.DataAccess.Test/GiveCRM.DataAccess.Test.csproj
+++ b/src/GiveCRM.DataAccess.Test/GiveCRM.DataAccess.Test.csproj
@@ -83,6 +83,7 @@
     <Compile Include="CampaignsTest.cs" />
     <Compile Include="FacetSetUpHelper.cs" />
     <Compile Include="FacetsTest.cs" />
+    <Compile Include="FakeDatabaseProvider.cs" />
     <Compile Include="MemberFacetsTest.cs" />
     <Compile Include="MembersTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/GiveCRM.DataAccess.Test/MemberFacetsTest.cs
+++ b/src/GiveCRM.DataAccess.Test/MemberFacetsTest.cs
@@ -108,7 +108,7 @@ namespace GiveCRM.DataAccess.Test
             Assert.IsNotNull(actualMemberTextFacet);
         }
 
-        private static Member CreateBob()
+        private Member CreateBob()
         {
             var member = new Member
                              {
@@ -119,7 +119,7 @@ namespace GiveCRM.DataAccess.Test
                                  Salutation = "Bob",
                                  EmailAddress = "bob@hotmail.com"
                              };
-            member = new Members().Insert(member);
+            member = new Members(databaseProvider).Insert(member);
             return member;
         }
     }

--- a/src/GiveCRM.DataAccess.Test/MemberFacetsTest.cs
+++ b/src/GiveCRM.DataAccess.Test/MemberFacetsTest.cs
@@ -9,11 +9,14 @@ namespace GiveCRM.DataAccess.Test
     [TestFixture]
     public class MemberFacetsTest
     {
-        private readonly dynamic db = Database.OpenNamedConnection("GiveCRM");
+        private IDatabaseProvider databaseProvider;
 
         [SetUp]
         public void SetUp()
         {
+            databaseProvider = new DatabaseProvider();
+            dynamic db = databaseProvider.GetDatabase();
+
             db.Donations.DeleteAll();
             db.CampaignRuns.DeleteAll();
             db.Campaigns.DeleteAll();
@@ -39,7 +42,7 @@ namespace GiveCRM.DataAccess.Test
             Assert.AreEqual("Aardvark", facet.FreeTextValue);
         }
 
-        private static MemberFacetFreeText CreateFreeTextMemberFacet(Member member, Facet textFacet)
+        private MemberFacetFreeText CreateFreeTextMemberFacet(Member member, Facet textFacet)
         {
             var facet = new MemberFacetFreeText
                             {
@@ -47,7 +50,7 @@ namespace GiveCRM.DataAccess.Test
                                 MemberId = member.Id,
                                 FreeTextValue = "Aardvark"
                             };
-            facet = new MemberFacets().Insert(facet);
+            facet = new MemberFacets(databaseProvider).Insert(facet);
             return facet;
         }
 
@@ -68,7 +71,7 @@ namespace GiveCRM.DataAccess.Test
             Assert.AreEqual(listFacet.Values.Last().Id, facet.Values.Last().FacetValueId);
         }
 
-        private static MemberFacetList CreateListMemberFacet(Member member, Facet listFacet)
+        private MemberFacetList CreateListMemberFacet(Member member, Facet listFacet)
         {
             var facet = new MemberFacetList
                             {
@@ -80,7 +83,7 @@ namespace GiveCRM.DataAccess.Test
                                                  new MemberFacetValue {FacetValueId = listFacet.Values.Last().Id},
                                              }
                             };
-            facet = new MemberFacets().Insert(facet);
+            facet = new MemberFacets(databaseProvider).Insert(facet);
             return facet;
         }
 
@@ -95,7 +98,7 @@ namespace GiveCRM.DataAccess.Test
             var expectedMemberListFacet = CreateListMemberFacet(member, listFacet);
             var expectedMemberTextFacet = CreateFreeTextMemberFacet(member, textFacet);
 
-            var facets = new MemberFacets().ForMember(member.Id).ToList();
+            var facets = new MemberFacets(databaseProvider).ForMember(member.Id).ToList();
 
             var actualMemberListFacet = facets.OfType<MemberFacetList>().FirstOrDefault();
             Assert.IsNotNull(actualMemberListFacet);

--- a/src/GiveCRM.DataAccess.Test/MembersTest.cs
+++ b/src/GiveCRM.DataAccess.Test/MembersTest.cs
@@ -63,7 +63,7 @@ namespace GiveCRM.DataAccess.Test
         [Test]
         public void Get()
         {
-            var members = new Members();
+            var members = new Members(databaseProvider);
             Member member = CreateAliceWithPhoneNumber();
             member = members.Insert(member);
 
@@ -91,7 +91,7 @@ namespace GiveCRM.DataAccess.Test
         [Test]
         public void All()
         {
-            var members = new Members();
+            var members = new Members(databaseProvider);
             Member member = CreateAliceWithPhoneNumber();
             member = members.Insert(member);
             var donations = new Donations(databaseProvider);
@@ -127,7 +127,7 @@ namespace GiveCRM.DataAccess.Test
         [Test]
         public void InsertMember()
         {
-            var members = new Members();
+            var members = new Members(databaseProvider);
             Member member = CreateAlice();
             member = members.Insert(member);
             Assert.AreNotEqual(0, member.Id);
@@ -136,7 +136,7 @@ namespace GiveCRM.DataAccess.Test
         [Test]
         public void InsertMemberWithPhoneNumber()
         {
-            var members = new Members();
+            var members = new Members(databaseProvider);
             Member member = CreateAliceWithPhoneNumber();
             member = members.Insert(member);
             Assert.AreNotEqual(0, member.Id);

--- a/src/GiveCRM.DataAccess.Test/MembersTest.cs
+++ b/src/GiveCRM.DataAccess.Test/MembersTest.cs
@@ -13,6 +13,8 @@ namespace GiveCRM.DataAccess.Test
         [SetUp]
         public void SetUp()
         {
+            databaseProvider = new DatabaseProvider();
+            dynamic db = databaseProvider.GetDatabase();
             db.Donations.DeleteAll();
             db.CampaignRuns.DeleteAll();
             db.Campaigns.DeleteAll();
@@ -22,7 +24,7 @@ namespace GiveCRM.DataAccess.Test
             db.Members.DeleteAll();
         }
 
-        private readonly dynamic db = Database.OpenNamedConnection("GiveCRM");
+        private IDatabaseProvider databaseProvider;
 
         private static Member CreateAliceWithPhoneNumber()
         {
@@ -92,7 +94,7 @@ namespace GiveCRM.DataAccess.Test
             var members = new Members();
             Member member = CreateAliceWithPhoneNumber();
             member = members.Insert(member);
-            var donations = new Donations();
+            var donations = new Donations(databaseProvider);
             donations.Insert(new Donation {MemberId = member.Id, Amount = 12.50m, Date = DateTime.Today});
             donations.Insert(new Donation { MemberId = member.Id, Amount = 12.50m, Date = DateTime.Today.Subtract(TimeSpan.FromDays(1)) });
 

--- a/src/GiveCRM.DataAccess.Test/SearchTest.cs
+++ b/src/GiveCRM.DataAccess.Test/SearchTest.cs
@@ -24,7 +24,7 @@ namespace GiveCRM.DataAccess.Test
                                        }
                                };
 
-            var expr = new SearchQueryService().CompileLocationCriteria(criteria, null);
+            var expr = new SearchQueryService(new DatabaseProvider()).CompileLocationCriteria(criteria, null);
 
             var reference = expr.LeftOperand as ObjectReference;
             Assert.IsNotNull(reference);
@@ -47,7 +47,7 @@ namespace GiveCRM.DataAccess.Test
                                        }
                                };
 
-            var expr = new SearchQueryService().CompileLocationCriteria(criteria, null);
+            var expr = new SearchQueryService(new DatabaseProvider()).CompileLocationCriteria(criteria, null);
 
             var reference = expr.LeftOperand as ObjectReference;
             Assert.IsNotNull(reference);
@@ -70,7 +70,7 @@ namespace GiveCRM.DataAccess.Test
                                        }
                                };
 
-            var expr = new SearchQueryService().CompileLocationCriteria(criteria, null);
+            var expr = new SearchQueryService(new DatabaseProvider()).CompileLocationCriteria(criteria, null);
 
             var reference = expr.LeftOperand as ObjectReference;
             Assert.IsNotNull(reference);
@@ -99,7 +99,7 @@ namespace GiveCRM.DataAccess.Test
 
             SimpleExpression expr = null;
             SimpleExpression having = null;
-            new SearchQueryService().CompileDonationCriteria(criteria, ref expr, ref having);
+            new SearchQueryService(new DatabaseProvider()).CompileDonationCriteria(criteria, ref expr, ref having);
 
             Assert.IsNotNull(expr);
             Assert.IsNull(having);
@@ -127,7 +127,7 @@ namespace GiveCRM.DataAccess.Test
 
             SimpleExpression expr = null;
             SimpleExpression having = null;
-            new SearchQueryService().CompileDonationCriteria(criteria, ref expr, ref having);
+            new SearchQueryService(new DatabaseProvider()).CompileDonationCriteria(criteria, ref expr, ref having);
 
             Assert.IsNull(expr);
             Assert.IsNotNull(having);
@@ -157,7 +157,7 @@ namespace GiveCRM.DataAccess.Test
 
             SimpleExpression expr = null;
             SimpleExpression having = null;
-            new SearchQueryService().CompileDonationCriteria(criteria, ref expr, ref having);
+            new SearchQueryService(new DatabaseProvider()).CompileDonationCriteria(criteria, ref expr, ref having);
 
             Assert.IsNull(expr);
             Assert.IsNotNull(having);
@@ -186,7 +186,7 @@ namespace GiveCRM.DataAccess.Test
                                        }
                                };
 
-            var expr = new SearchQueryService().CompileCampaignCriteria(criteria, null);
+            var expr = new SearchQueryService(new DatabaseProvider()).CompileCampaignCriteria(criteria, null);
 
             var reference = expr.LeftOperand as ObjectReference;
             Assert.IsNotNull(reference);
@@ -202,7 +202,7 @@ namespace GiveCRM.DataAccess.Test
         [Test]
         public void Facet()
         {
-            var search = new SearchQueryService();
+            var search = new SearchQueryService(new DatabaseProvider());
             var criteria = new[]
                                {
                                    new FacetSearchCriteria

--- a/src/GiveCRM.DataAccess/Campaigns.cs
+++ b/src/GiveCRM.DataAccess/Campaigns.cs
@@ -3,39 +3,41 @@ using System.Collections.Generic;
 using System.Linq;
 using GiveCRM.BusinessLogic;
 using GiveCRM.Models;
-using Simple.Data;
 
 namespace GiveCRM.DataAccess
 {
-
-
     public class Campaigns : ICampaignRepository
     {
-        private readonly dynamic db = Database.OpenNamedConnection("GiveCRM");
+        private readonly IDatabaseProvider databaseProvider;
+
+        public Campaigns(IDatabaseProvider databaseProvider)
+        {
+            this.databaseProvider = databaseProvider;
+        }
 
         public Campaign GetById(int id)
         {
-            return db.Campaigns.FindById(id);
+            return databaseProvider.GetDatabase().Campaigns.FindById(id);
         }
 
         public IEnumerable<Campaign> GetAll()
         {
-            return db.Campaigns.All().OrderByRunOnDescending().Cast<Campaign>();
+            return databaseProvider.GetDatabase().Campaigns.All().OrderByRunOnDescending().Cast<Campaign>();
         }
 
         public IEnumerable<Campaign> GetAllOpen()
         {
-            return db.Campaigns.FindAllByIsClosed('N').OrderByRunOnDescending().Cast<Campaign>();
+            return databaseProvider.GetDatabase().Campaigns.FindAllByIsClosed('N').OrderByRunOnDescending().Cast<Campaign>();
         }
 
         public IEnumerable<Campaign> GetAllClosed()
         {
-            return db.Campaigns.FindAllByIsClosed('Y').OrderByRunOnDescending().Cast<Campaign>();
+            return databaseProvider.GetDatabase().Campaigns.FindAllByIsClosed('Y').OrderByRunOnDescending().Cast<Campaign>();
         }
 
         public Campaign Insert(Campaign campaign)
         {
-            return db.Campaigns.Insert(campaign);
+            return databaseProvider.GetDatabase().Campaigns.Insert(campaign);
         }
 
         /// <summary>
@@ -44,19 +46,19 @@ namespace GiveCRM.DataAccess
         /// <param name="id">The identifier of the campaign to delete.</param>
         public void DeleteById(int id)
         {
-            db.Campaigns.Delete(id);
+            databaseProvider.GetDatabase().Campaigns.Delete(id);
         }
 
         public void Update(Campaign campaign)
         {
-            db.Campaigns.UpdateById(campaign);
+            databaseProvider.GetDatabase().Campaigns.UpdateById(campaign);
         }
 
         public void Commit(int campaignId, IEnumerable<Member> campaignMembers)
         {
             var results = campaignMembers.Select(member => new { CampaignId = campaignId, MemberId = member.Id });
 
-            using (var transaction = db.BeginTransaction())
+            using (var transaction = databaseProvider.GetDatabase().BeginTransaction())
             {
                 try
                 {

--- a/src/GiveCRM.DataAccess/DatabaseProvider.cs
+++ b/src/GiveCRM.DataAccess/DatabaseProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace GiveCRM.DataAccess
+{
+    using Simple.Data;
+
+    public class DatabaseProvider : IDatabaseProvider
+    {
+        private readonly dynamic database = Database.OpenNamedConnection("GiveCRM");
+
+        public dynamic GetDatabase()
+        {
+            return database;
+        }
+    }
+}

--- a/src/GiveCRM.DataAccess/Donations.cs
+++ b/src/GiveCRM.DataAccess/Donations.cs
@@ -5,40 +5,43 @@ using Simple.Data;
 
 namespace GiveCRM.DataAccess
 {
-
-
     public class Donations : IDonationRepository
     {
-        private readonly dynamic db = Database.OpenNamedConnection("GiveCRM");
+        private readonly IDatabaseProvider databaseProvider;
+
+        public Donations(IDatabaseProvider databaseProvider)
+        {
+            this.databaseProvider = databaseProvider;
+        }
 
         public Donation GetById(int id)
         {
-            return db.Donations.FindById(id);
+            return databaseProvider.GetDatabase().Donations.FindById(id);
         }
 
         public void Update(Donation item)
         {
-            db.Donations.UpdateById(item);
+            databaseProvider.GetDatabase().Donations.UpdateById(item);
         }
 
         public IEnumerable<Donation> GetAll()
         {
-            return db.Donations.All().Cast<Donation>();
+            return databaseProvider.GetDatabase().Donations.All().Cast<Donation>();
         }
 
         public IEnumerable<Donation> GetByMemberId(int memberId)
         {
-            return db.Donations.FindByMemberId(memberId).Cast<Donation>();
+            return databaseProvider.GetDatabase().Donations.FindByMemberId(memberId).Cast<Donation>();
         }
 
         public IEnumerable<Donation> GetByCampaignId(int campaignId)
         {
-            return db.Donations.FindByCampaignId(campaignId).Cast<Donation>();
+            return databaseProvider.GetDatabase().Donations.FindByCampaignId(campaignId).Cast<Donation>();
         }
 
         public Donation Insert(Donation donation)
         {
-            return db.Donations.Insert(donation);
+            return databaseProvider.GetDatabase().Donations.Insert(donation);
         }
 
         /// <summary>
@@ -47,7 +50,7 @@ namespace GiveCRM.DataAccess
         /// <param name="id">The identifier of the donation to delete.</param>
         public void DeleteById(int id)
         {
-            db.Donations.DeleteById(id);
+            databaseProvider.GetDatabase().Donations.DeleteById(id);
         }
     }
 }

--- a/src/GiveCRM.DataAccess/Facets.cs
+++ b/src/GiveCRM.DataAccess/Facets.cs
@@ -9,11 +9,16 @@ namespace GiveCRM.DataAccess
 
     public class Facets : IFacetRepository
     {
-        private readonly dynamic db = Database.OpenNamedConnection("GiveCRM");
+        private readonly IDatabaseProvider databaseProvider;
+
+        public Facets(IDatabaseProvider databaseProvider)
+        {
+            this.databaseProvider = databaseProvider;
+        }
 
         public Facet GetById(int id)
         {
-            var record = db.Facets.FindById(id);
+            var record = databaseProvider.GetDatabase().Facets.FindById(id);
             Facet facet = record;
             facet.Values = record.FacetValues.ToList<FacetValue>();
             return facet;
@@ -21,6 +26,7 @@ namespace GiveCRM.DataAccess
 
         public IEnumerable<Facet> GetAll()
         {
+            dynamic db = databaseProvider.GetDatabase();
             var query = db.Facets.All()
                 .Select(db.Facets.Id, db.Facets.Type, db.Facets.Name,
                         db.Facets.FacetValues.Id.As("FacetValueId"), db.Facets.FacetValues.FacetId, db.Facets.FacetValues.Value)
@@ -61,7 +67,7 @@ namespace GiveCRM.DataAccess
             {
                 return InsertWithValues(facet);
             }
-            var record = db.Facets.Insert(facet);
+            var record = databaseProvider.GetDatabase().Facets.Insert(facet);
             return record;
         }
 
@@ -71,7 +77,7 @@ namespace GiveCRM.DataAccess
         /// <param name="id">The identifier of the Facet to delete.</param>
         public void DeleteById(int id)
         {
-            db.Facets.DeleteById(id);
+            databaseProvider.GetDatabase().Facets.DeleteById(id);
         }
 
         public void Update(Facet facet)
@@ -82,13 +88,13 @@ namespace GiveCRM.DataAccess
             }
             else
             {
-                db.Facets.UpdateById(facet);
+                databaseProvider.GetDatabase().Facets.UpdateById(facet);
             }
         }
 
         private void UpdateWithValues(Facet facet)
         {
-            using (var transaction = db.BeginTransaction())
+            using (var transaction = databaseProvider.GetDatabase().BeginTransaction())
             {
                 try
                 {
@@ -121,7 +127,7 @@ namespace GiveCRM.DataAccess
 
         private Facet InsertWithValues(Facet facet)
         {
-            using (var transaction = db.BeginTransaction())
+            using (var transaction = databaseProvider.GetDatabase().BeginTransaction())
             {
                 try
                 {
@@ -144,7 +150,7 @@ namespace GiveCRM.DataAccess
 
         public IEnumerable<Facet> GetAllFreeText()
         {
-            return db.Facets.FindAllByType(FacetType.FreeText.ToString()).Cast<Facet>();
+            return databaseProvider.GetDatabase().Facets.FindAllByType(FacetType.FreeText.ToString()).Cast<Facet>();
         }
     }
 }

--- a/src/GiveCRM.DataAccess/GiveCRM.DataAccess.csproj
+++ b/src/GiveCRM.DataAccess/GiveCRM.DataAccess.csproj
@@ -55,8 +55,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Campaigns.cs" />
+    <Compile Include="DatabaseProvider.cs" />
     <Compile Include="Donations.cs" />
     <Compile Include="Facets.cs" />
+    <Compile Include="IDatabaseProvider.cs" />
     <Compile Include="MemberFacets.cs" />
     <Compile Include="Members.cs" />
     <Compile Include="MemberSearchFilters.cs" />

--- a/src/GiveCRM.DataAccess/IDatabaseProvider.cs
+++ b/src/GiveCRM.DataAccess/IDatabaseProvider.cs
@@ -1,0 +1,7 @@
+namespace GiveCRM.DataAccess
+{
+    public interface IDatabaseProvider
+    {
+        dynamic GetDatabase();
+    }
+}

--- a/src/GiveCRM.DataAccess/MemberFacets.cs
+++ b/src/GiveCRM.DataAccess/MemberFacets.cs
@@ -5,14 +5,19 @@ using Simple.Data;
 
 namespace GiveCRM.DataAccess
 {
-
-
     public class MemberFacets
     {
-        private readonly dynamic db = Database.OpenNamedConnection("GiveCRM");
+        private readonly IDatabaseProvider databaseProvider;
+
+        public MemberFacets(IDatabaseProvider databaseProvider)
+        {
+            this.databaseProvider = databaseProvider;
+        }
 
         public IEnumerable<MemberFacet> ForMember(int memberId)
         {
+            dynamic db = databaseProvider.GetDatabase();
+
             var query = db.MemberFacets.FindAllByMemberId(memberId)
                 .Select(db.MemberFacets.ID, db.MemberFacets.FacetId, db.MemberFacets.FreeTextValue,
                         db.MemberFacets.MemberFacetValue.FacetValueId,
@@ -78,12 +83,12 @@ namespace GiveCRM.DataAccess
 
         public MemberFacetFreeText Insert(MemberFacetFreeText facet)
         {
-            return db.MemberFacets.Insert(facet);
+            return databaseProvider.GetDatabase().MemberFacets.Insert(facet);
         }
 
         public MemberFacetList Insert(MemberFacetList facet)
         {
-            using (var transaction = db.BeginTransaction())
+            using (var transaction = databaseProvider.GetDatabase().BeginTransaction())
             {
                 try
                 {

--- a/src/GiveCRM.DataAccess/MemberSearchFilters.cs
+++ b/src/GiveCRM.DataAccess/MemberSearchFilters.cs
@@ -5,40 +5,43 @@ using Simple.Data;
 
 namespace GiveCRM.DataAccess
 {
-
-
     public class MemberSearchFilters : IMemberSearchFilterRepository
     {
-        private readonly dynamic db = Database.OpenNamedConnection("GiveCRM");
+        private readonly IDatabaseProvider databaseProvider;
+
+        public MemberSearchFilters(IDatabaseProvider databaseProvider)
+        {
+            this.databaseProvider = databaseProvider;
+        }
 
         public IEnumerable<MemberSearchFilter> GetByCampaignId(int campaignId)
         {
-            return db.MemberSearchFilters.FindAllByCampaignId(campaignId).Cast<MemberSearchFilter>();
+            return databaseProvider.GetDatabase().MemberSearchFilters.FindAllByCampaignId(campaignId).Cast<MemberSearchFilter>();
         }
 
         public IEnumerable<MemberSearchFilter> GetAll()
         {
-            return db.MemberSearchFilters.All();
+            return databaseProvider.GetDatabase().MemberSearchFilters.All();
         }
 
         public MemberSearchFilter GetById(int id)
         {
-            return db.MemberSearchFilters.FindById(id);
+            return databaseProvider.GetDatabase().MemberSearchFilters.FindById(id);
         }
 
         public void Update(MemberSearchFilter item)
         {
-            db.MemberSearchFilters.UpdateById(item);
+            databaseProvider.GetDatabase().MemberSearchFilters.UpdateById(item);
         }
 
         public MemberSearchFilter Insert(MemberSearchFilter memberSearchFilter)
         {
-            return db.MemberSearchFilters.Insert(memberSearchFilter);
+            return databaseProvider.GetDatabase().MemberSearchFilters.Insert(memberSearchFilter);
         }
         
         public void DeleteById(int id)
         {
-            db.MemberSearchFilters.DeleteById(id);
+            databaseProvider.GetDatabase().MemberSearchFilters.DeleteById(id);
         }
     }
 }

--- a/src/GiveCRM.DummyDataGenerator/Generation/CampaignGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/CampaignGenerator.cs
@@ -12,13 +12,13 @@ namespace GiveCRM.DummyDataGenerator.Generation
         private readonly RandomSource random = new RandomSource();
         private readonly MemberSearchFilterGenerator memberSearchFilterGenerator = new MemberSearchFilterGenerator();
         private readonly CampaignRunGenerator campaignRunGenerator = new CampaignRunGenerator();
-
+        
         public CampaignGenerator(Action<string> logAction) : base(logAction)
         {}
 
         internal override void Generate(int numberToGenerate)
         {
-            Campaigns campaigns = new Campaigns();
+            Campaigns campaigns = new Campaigns(new DatabaseProvider());
             GenerateMultiple(numberToGenerate, () =>
                                                    {
                                                        var campaign = GenerateCampaign();

--- a/src/GiveCRM.DummyDataGenerator/Generation/CampaignGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/CampaignGenerator.cs
@@ -7,18 +7,27 @@ namespace GiveCRM.DummyDataGenerator.Generation
 {
     internal class CampaignGenerator : BaseGenerator
     {
-        internal override string GeneratedItemType{get {return "campaigns";}}
+        internal override string GeneratedItemType
+        {
+            get { return "campaigns"; }
+        }
 
-        private readonly RandomSource random = new RandomSource();
-        private readonly MemberSearchFilterGenerator memberSearchFilterGenerator = new MemberSearchFilterGenerator();
-        private readonly CampaignRunGenerator campaignRunGenerator = new CampaignRunGenerator();
+        private readonly IDatabaseProvider databaseProvider;
+        private readonly RandomSource random;
+        private readonly MemberSearchFilterGenerator memberSearchFilterGenerator;
+        private readonly CampaignRunGenerator campaignRunGenerator;
         
         public CampaignGenerator(Action<string> logAction) : base(logAction)
-        {}
+        {
+            databaseProvider = new DatabaseProvider();
+            random = new RandomSource();
+            memberSearchFilterGenerator = new MemberSearchFilterGenerator();
+            campaignRunGenerator = new CampaignRunGenerator(databaseProvider);
+        }
 
         internal override void Generate(int numberToGenerate)
         {
-            Campaigns campaigns = new Campaigns(new DatabaseProvider());
+            Campaigns campaigns = new Campaigns(databaseProvider);
             GenerateMultiple(numberToGenerate, () =>
                                                    {
                                                        var campaign = GenerateCampaign();

--- a/src/GiveCRM.DummyDataGenerator/Generation/CampaignRunGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/CampaignRunGenerator.cs
@@ -13,7 +13,7 @@ namespace GiveCRM.DummyDataGenerator.Generation
         public CampaignRunGenerator(IDatabaseProvider databaseProvider)
         {
             this.databaseProvider = databaseProvider;
-            memberService = new MemberService(new Members(databaseProvider), new MemberSearchFilters(), new SearchQueryService());
+            memberService = new MemberService(new Members(databaseProvider), new MemberSearchFilters(databaseProvider), new SearchQueryService());
         }
 
         internal void GenerateCampaignRun(int campaignId)

--- a/src/GiveCRM.DummyDataGenerator/Generation/CampaignRunGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/CampaignRunGenerator.cs
@@ -7,8 +7,14 @@ namespace GiveCRM.DummyDataGenerator.Generation
 {
     internal class CampaignRunGenerator
     {
-        private readonly dynamic db = Database.OpenNamedConnection("GiveCRM");
-        private readonly MemberService memberService = new MemberService(new Members(), new MemberSearchFilters(), new SearchQueryService());
+        private readonly IDatabaseProvider databaseProvider;
+        private readonly MemberService memberService;
+
+        public CampaignRunGenerator(IDatabaseProvider databaseProvider)
+        {
+            this.databaseProvider = databaseProvider;
+            memberService = new MemberService(new Members(databaseProvider), new MemberSearchFilters(), new SearchQueryService());
+        }
 
         internal void GenerateCampaignRun(int campaignId)
         {
@@ -17,7 +23,7 @@ namespace GiveCRM.DummyDataGenerator.Generation
 
             if (memberCampaignMemberships.Any())
             {
-                db.CampaignRuns.Insert(memberCampaignMemberships);
+                databaseProvider.GetDatabase().CampaignRuns.Insert(memberCampaignMemberships);
             }
         }
     }

--- a/src/GiveCRM.DummyDataGenerator/Generation/CampaignRunGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/CampaignRunGenerator.cs
@@ -13,7 +13,8 @@ namespace GiveCRM.DummyDataGenerator.Generation
         public CampaignRunGenerator(IDatabaseProvider databaseProvider)
         {
             this.databaseProvider = databaseProvider;
-            memberService = new MemberService(new Members(databaseProvider), new MemberSearchFilters(databaseProvider), new SearchQueryService());
+            memberService = new MemberService(new Members(databaseProvider), new MemberSearchFilters(databaseProvider),
+                                              new SearchQueryService(databaseProvider));
         }
 
         internal void GenerateCampaignRun(int campaignId)

--- a/src/GiveCRM.DummyDataGenerator/Generation/DonationGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/DonationGenerator.cs
@@ -30,7 +30,7 @@ namespace GiveCRM.DummyDataGenerator.Generation
             // only want to generate donations for committed campaigns
             var committedCampaigns = campaigns.Where(c => c.IsCommitted).ToList();
             var databaseProvider = new DatabaseProvider();
-            var members = new Members();
+            var members = new Members(databaseProvider);
             var donations = new Donations(databaseProvider);
 
             foreach (var campaign in committedCampaigns)

--- a/src/GiveCRM.DummyDataGenerator/Generation/DonationGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/DonationGenerator.cs
@@ -29,8 +29,9 @@ namespace GiveCRM.DummyDataGenerator.Generation
 
             // only want to generate donations for committed campaigns
             var committedCampaigns = campaigns.Where(c => c.IsCommitted).ToList();
+            var databaseProvider = new DatabaseProvider();
             var members = new Members();
-            var donations = new Donations();
+            var donations = new Donations(databaseProvider);
 
             foreach (var campaign in committedCampaigns)
             {

--- a/src/GiveCRM.DummyDataGenerator/Generation/MemberGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/MemberGenerator.cs
@@ -22,7 +22,7 @@ namespace GiveCRM.DummyDataGenerator.Generation
 
         internal override void Generate(int numberToGenerate)
         {
-            Members membersDb = new Members();
+            Members membersDb = new Members(new DatabaseProvider());
             GenerateMultiple(numberToGenerate, () =>
                                                    {
                                                        var member = GenerateMember();

--- a/src/GiveCRM.DummyDataGenerator/Generation/MemberSearchFilterGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/MemberSearchFilterGenerator.cs
@@ -14,7 +14,7 @@ namespace GiveCRM.DummyDataGenerator.Generation
     {
         private readonly RandomSource random = new RandomSource();
         private readonly MemberSearchFilters searchFilters = new MemberSearchFilters();
-        private readonly SearchService searchRepo = new SearchService(new Facets());
+        private readonly SearchService searchRepo = new SearchService(new Facets(new DatabaseProvider()));
 
         private readonly Dictionary<SearchFieldType, IList<SearchOperator>> fieldTypeToOperatorMap;
 

--- a/src/GiveCRM.DummyDataGenerator/Generation/MemberSearchFilterGenerator.cs
+++ b/src/GiveCRM.DummyDataGenerator/Generation/MemberSearchFilterGenerator.cs
@@ -12,14 +12,19 @@ namespace GiveCRM.DummyDataGenerator.Generation
 {
     internal class MemberSearchFilterGenerator
     {
-        private readonly RandomSource random = new RandomSource();
-        private readonly MemberSearchFilters searchFilters = new MemberSearchFilters();
-        private readonly SearchService searchRepo = new SearchService(new Facets(new DatabaseProvider()));
+        private readonly RandomSource random;
+        private readonly MemberSearchFilters searchFilters;
+        private readonly SearchService searchRepo;
 
         private readonly Dictionary<SearchFieldType, IList<SearchOperator>> fieldTypeToOperatorMap;
 
         public MemberSearchFilterGenerator()
         {
+            var databaseProvider = new DatabaseProvider();
+            random = new RandomSource();
+            searchFilters = new MemberSearchFilters(databaseProvider);
+            searchRepo = new SearchService(new Facets(databaseProvider));
+
             fieldTypeToOperatorMap = new Dictionary<SearchFieldType, IList<SearchOperator>>();
 
             var allTypesHave = new[]


### PR DESCRIPTION
Previously each repository concrete instance would create it's own Simple.Data database object, which would mean each repository would have it's own database connection beneath that.

These changes mean the "database" is effectively now controlled by the IoC container with a "per web request" lifestyle. We can therefore wrap calls on multiple repository objects in TransactionScope without having the transaction promoted to a distributed transaction (which would require MSDTC to be active and severely harm performance).
