### PR TITLE
Clarify Git Flow usage and installation.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -27,27 +27,27 @@ We'll do a bit of a code review before accepting your patch.
 
 ### Git Flow
 
-You will notice when you first clone the GiveCRM repository that the default branch is `develop` rather than the more usual `master`.  We use the Git Flow branching model, [first described](http://nvie.com/posts/a-successful-git-branching-model/) by [nvie](http://www.twitter.com/nvie), so `master` moves on only at specific points.  
+You will notice when you fork the GiveCRM repository that the default branch is `develop` rather than the more usual `master`.  We use the Git Flow branching model, [first described](http://nvie.com/posts/a-successful-git-branching-model/) by [nvie](http://www.twitter.com/nvie), so GiveCRM's `master` branch moves on only at specific points, when we're really sure we want to promote something to production.  
 
 **Use of Git Flow is not required for contributing to GiveCRM**, particularly if you're submitting a bug-fix or small feature.  Its use is recommended for larger changes where develop might move on whilst you're completing your work.
 
 #### Configuring Git Flow
 
-There is a set of [helper scripts](https://github.com/nvie/gitflow) that will work on both Unix-based operating systems and Windows.  Follow the appropriate [installation instructions](https://github.com/nvie/gitflow/wiki/Installation) for your operating system, and configure your clone of GiveCRM for use with Git Flow by typing `git flow init`.  
+There is a set of [helper scripts](https://github.com/nvie/gitflow) that will work on both Unix-based operating systems and Windows.  Follow the appropriate [installation instructions](https://github.com/nvie/gitflow/wiki/Installation) for your operating system, and configure your working copy repository for use with Git Flow by typing `git flow init`.  
 
 #### Using Git Flow
 
-Pick a feature or bug to work on and create a new branch for that work by typing `git flow feature start <featurename>`.  This will create you a new branch for your work, and you can use git as usual from this point.  
+Pick a feature or bug to work on and create a new branch for that work by typing `git flow feature start <featurename>`.  This will create you a new *feature branch* for your work called `feature/<featurename>`, and you can use git as usual from this point.  
 
-Once your feature is finished, type `git flow feature publish <featurename>`.  This will push the feature up to your `origin` repository on GitHub and you will then be able to submit a pull request to have it merged into `develop`.  **Note: do not use `git flow feature finish <featurename>`!**  This will automatically merge your feature branch back into `develop` and delete the feature branch, making it harder for you to submit your pull request.
+Once your feature is finished, type `git flow feature publish <featurename>`.  This will copy the *feature branch* to your `origin` repository on GitHub and you will then be able to submit a pull request to have it merged into GiveCRM's own `develop` branch.  **Note: do not use `git flow feature finish <featurename>`!**  This will automatically merge your *feature branch* back into `develop` and delete the *feature branch*, making it harder for you to submit your pull request.
 
-If you find `develop` has moved on, and you need/want to take advantage of the changes made there, you can update your feature branch as follows:
+If you find GiveCRM's `develop` branch has moved on, and you need/want to take advantage of the changes made there, you can update your feature branch as follows:
 
   1. Ensure you have a remote configured for the upstream repository.  You can use `git remote add upstream git://github.com/GiveCampUK/GiveCRM.git` to add it if it doesn't already exist.
   2. Type `git pull upstream develop:develop` to update your local repository with the upstream refs.
   3. Type `git flow feature rebase <featurename>` to rebase your feature branch on top of the new `develop`.
   
-There is a lot of help available for Git Flow, which can generally be accessed by typing `git flow feature help`.
+There is a lot of help available for Git Flow, which can be accessed by typing `git flow feature help`.
 
 ## Join the conversation
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -29,7 +29,7 @@ We'll do a bit of a code review before accepting your patch.
 
 You will notice when you fork the GiveCRM repository that the default branch is `develop` rather than the more usual `master`.  We use the Git Flow branching model, [first described](http://nvie.com/posts/a-successful-git-branching-model/) by [nvie](http://www.twitter.com/nvie), so GiveCRM's `master` branch moves on only at specific points, when we're really sure we want to promote something to production.  
 
-**Use of Git Flow is not required for contributing to GiveCRM**, particularly if you're submitting a bug-fix or small feature.  Its use is recommended for larger changes where develop might move on whilst you're completing your work.
+**Use of Git Flow is not required for contributing to GiveCRM**, particularly if you're submitting a bug-fix or small feature.  Its use is recommended for larger changes where `develop` might move on whilst you're completing your work.
 
 #### Configuring Git Flow
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -33,13 +33,15 @@ You will notice when you fork the GiveCRM repository that the default branch is 
 
 #### Configuring Git Flow
 
-There is a set of [helper scripts](https://github.com/nvie/gitflow) that will work on both Unix-based operating systems and Windows.  Follow the appropriate [installation instructions](https://github.com/nvie/gitflow/wiki/Installation) for your operating system, and configure your working copy repository for use with Git Flow by typing `git flow init`.  
+There is a set of [helper scripts](https://github.com/nvie/gitflow) that will work on both Unix-based operating systems and Windows.  Follow the appropriate [installation instructions](https://github.com/nvie/gitflow/wiki/Installation) for your operating system, and configure your working copy repository for use with Git Flow by typing `git flow init`.  Accept all the default options to the questions that it asks you.
 
 #### Using Git Flow
 
 Pick a feature or bug to work on and create a new branch for that work by typing `git flow feature start <featurename>`.  This will create you a new *feature branch* for your work called `feature/<featurename>`, and you can use git as usual from this point.  
 
 Once your feature is finished, type `git flow feature publish <featurename>`.  This will copy the *feature branch* to your `origin` repository on GitHub and you will then be able to submit a pull request to have it merged into GiveCRM's own `develop` branch.  **Note: do not use `git flow feature finish <featurename>`!**  This will automatically merge your *feature branch* back into `develop` and delete the *feature branch*, making it harder for you to submit your pull request.
+
+If you wish to update your published feature branch after the initial publish, use a regular `git push origin feature/<featurename>`.  This will also update your pull request if you have one open for that branch.
 
 If you find GiveCRM's `develop` branch has moved on, and you need/want to take advantage of the changes made there, you can update your feature branch as follows:
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -27,11 +27,27 @@ We'll do a bit of a code review before accepting your patch.
 
 ### Git Flow
 
-You will notice when you first clone the GiveCRM repository that the default branch is `develop` rather than the more usual `master`.  We use the Git Flow branching model, [first described](http://nvie.com/posts/a-successful-git-branching-model/) by [nvie](http://www.twitter.com/nvie), so `master` moves on only at specific points.  There is a set of [helper scripts](https://github.com/nvie/gitflow) that will work on both Unix-based operating systems and Windows.  
+You will notice when you first clone the GiveCRM repository that the default branch is `develop` rather than the more usual `master`.  We use the Git Flow branching model, [first described](http://nvie.com/posts/a-successful-git-branching-model/) by [nvie](http://www.twitter.com/nvie), so `master` moves on only at specific points.  
 
-Before you make any changes to your repository, configure your clone of GiveCRM for use with Git Flow by typing `git flow init`.  Pick a feature or bug to work on and create a new branch for that work by typing `git flow feature start <featurename>`.  This will create you a new branch for your work, and you can use git as usual from this point.  
+**Use of Git Flow is not required for contributing to GiveCRM**, particularly if you're submitting a bug-fix or small feature.  Its use is recommended for larger changes where develop might move on whilst you're completing your work.
 
-Once your feature is finished, type `git flow feature publish <featurename>`.  This will push the feature up to your `origin` repository on GitHub and you will then be able to submit a pull request to have it merged into `develop`.  
+#### Configuring Git Flow
+
+There is a set of [helper scripts](https://github.com/nvie/gitflow) that will work on both Unix-based operating systems and Windows.  Follow the appropriate [installation instructions](https://github.com/nvie/gitflow/wiki/Installation) for your operating system, and configure your clone of GiveCRM for use with Git Flow by typing `git flow init`.  
+
+#### Using Git Flow
+
+Pick a feature or bug to work on and create a new branch for that work by typing `git flow feature start <featurename>`.  This will create you a new branch for your work, and you can use git as usual from this point.  
+
+Once your feature is finished, type `git flow feature publish <featurename>`.  This will push the feature up to your `origin` repository on GitHub and you will then be able to submit a pull request to have it merged into `develop`.  **Note: do not use `git flow feature finish <featurename>`!**  This will automatically merge your feature branch back into `develop` and delete the feature branch, making it harder for you to submit your pull request.
+
+If you find `develop` has moved on, and you need/want to take advantage of the changes made there, you can update your feature branch as follows:
+
+  1. Ensure you have a remote configured for the upstream repository.  You can use `git remote add upstream git://github.com/GiveCampUK/GiveCRM.git` to add it if it doesn't already exist.
+  2. Type `git pull upstream develop:develop` to update your local repository with the upstream refs.
+  3. Type `git flow feature rebase <featurename>` to rebase your feature branch on top of the new `develop`.
+  
+There is a lot of help available for Git Flow, which can generally be accessed by typing `git flow feature help`.
 
 ## Join the conversation
 


### PR DESCRIPTION
Add further instructions as per [this comment](https://github.com/GiveCampUK/GiveCRM/pull/94#issuecomment-5006645) to clarify that usage of Git Flow is not required for contributing to GiveCRM, and to offer a bit more help with installation of Git Flow.

If there are any more comments, or stuff that I've missed, add them to this thread and leave the Pull Request open; I'll update it with new commits as I address the comments.

Ta

Alastair
